### PR TITLE
Customizations

### DIFF
--- a/packages.lisp
+++ b/packages.lisp
@@ -2,4 +2,7 @@
   (:use :cl)
   (:export :progressbar
            :make-progress
-           :step!))
+           :step!
+           :*default-width*
+           :*default-fill-character*
+	   :*default-background-character*))

--- a/progressons.asd
+++ b/progressons.asd
@@ -4,8 +4,7 @@
   :version "0.1"
   :author "vindarel"
   :license "MIT"
-  :depends-on ("alexandria"
-	       "str"
+  :depends-on ("str"
                "cl-ansi-text")
   :components ((:file "packages")
                (:file "utils")

--- a/progressons.asd
+++ b/progressons.asd
@@ -4,7 +4,8 @@
   :version "0.1"
   :author "vindarel"
   :license "MIT"
-  :depends-on ("str"
+  :depends-on ("alexandria"
+	       "str"
                "cl-ansi-text")
   :components ((:file "packages")
                (:file "utils")

--- a/progressons.lisp
+++ b/progressons.lisp
@@ -19,6 +19,7 @@ Usage:
   ((data :accessor progress-data
          :initarg :data)
    (width :accessor progress-width
+	  :initarg :width
           :initform *default-width*
           :documentation "Screen width.")
    (step-width :accessor step-width
@@ -60,14 +61,13 @@ You should rather create a progressbar with this preference enabled:
     (t
      (error "The progress bar data of type ~a is not valid." (type-of (progress-data obj))))))
 
-(defun make-progress (data &key (fill-character *default-fill-character*) rainbow)
+(defun make-progress (data &rest args)
   "A more manual way to create a progressbar than `progressbar'.
 
   DATA can be a sequence or an integer."
-  (setf *progress* (make-instance 'progress
-                                  :data data
-                                  :fill-character fill-character
-                                  :rainbow rainbow)))
+  (setf *progress* (apply #'make-instance 'progress
+                          :data data
+                          args)))
 
 (defmethod initialize-instance :after ((obj progress) &rest initargs &key &allow-other-keys)
   (declare (ignorable initargs))
@@ -261,16 +261,11 @@ one after the other, and we print the percent in the end."
 (defmethod reinit ((obj progress))
   (setf (steps-counter obj) 0))
 
-(defun progressbar (data &key bar rainbow)
+(defun progressbar (data &rest args)
   "Create a progress bar with this data. Return the data, so we can iterate over it.
 At the end of each iteration, you must call (step!) to print the progress.
 
 If `rainbow' is non-nil, print the steps in a random color."
   (setf *tty-p* (tty-p))
-  (make-progress data
-                 :rainbow rainbow
-                 :fill-character (if (stringp bar)
-                                     (character bar)
-                                     (or bar *default-fill-character*)))
-  (values (progress-data *progress*)
-          *progress*))
+  (apply #'make-progress data args)
+  (values (progress-data *progress*) *progress*))


### PR DESCRIPTION
This implements customization of progress-bar characters, also width.

Also I've changed how arguments are passed around, more freely, so it is possible to initialize progress-bar in-place.
For example, look at customization arguments being passed here (width and background-character):

```lisp
(loop for elt in (progressbar (loop for i from 1 to 20 collect i) :width 20 :background-character #\.)
   do ;;(do-something-with elt)
      (sleep (nth (random 4) (list 0.2 0.4 0.6 0.8)))
      (step!))
```

Also set default width to 60 instead of 80, to make room for percentages and current step/total steps.